### PR TITLE
Fix job matching without explicit Identifier keyword.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 
 Revision history for pyFreenet
 
+- Version 0.3.4
+    - fix missed messages, thanks to Steve
+    - fix DDA, thanks to Steve
+    - optimize site upload in freesitemgr
+    - add script copyweb (simpler interface to wget)
+    - some more debugging
+
 - Version 0.3.1
     - adding a freesite inserts it right away
     - mime-type fixes

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -1338,8 +1338,8 @@ class FCPNode:
             - WithPrivate - default False - if True, includes the node's private node reference fields
             - WithVolatile - default False - if True, returns a node's volatile info
         """
-        
-        return self._submitCmd("__global", "GetNode", **kw)
+        # The GetNode answer has no id, so we have to use __global.
+        return self._submitCmd("__global", "GetNode", identifier="__global", **kw)
     
     #@-node:refstats
     #@+node:testDDA

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -3278,6 +3278,8 @@ def guessMimetype(filename):
         m = mimetypes.guess_type(filename, False)[0]
     except:
         m = None
+    if m == "audio/mpegurl": # disallowed mime type
+        m = "audio/x-mpegurl"
     if m is None: # either an exception or a genuine None
         # FIXME: log(INFO, "Could not find mimetype for filename %s" % filename)
         m = "application/octet-stream"

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -1339,7 +1339,7 @@ class FCPNode:
             - WithVolatile - default False - if True, returns a node's volatile info
         """
         # The GetNode answer has no id, so we have to use __global.
-        return self._submitCmd("__global", "GetNode", identifier="__global", **kw)
+        return self._submitCmd("__global", "GetNode", **kw)
     
     #@-node:refstats
     #@+node:testDDA
@@ -2113,7 +2113,13 @@ class FCPNode:
         """
         if not self.nodeIsAlive:
             raise FCPNodeFailure("%s:%s: node closed connection" % (cmd, id))
-    
+
+        # if identifier is not given explicitly in the options, we
+        # need to add it to ensure that the replies find matching
+        # jobs.
+        if not "Identifier" in kw and not "identifier" in kw:
+            kw["Identifier"] = id
+        
         log = self._log
     
         log(DEBUG, "_submitCmd: id=" + repr(id) + ", cmd=" + repr(cmd) + ", **" + repr(kw))

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -1363,7 +1363,7 @@ class FCPNode:
             - WithWriteDirectory - default False - if True, want node to write to directory for a get operation
         """
         # cache the testDDA:
-        DDAkey = (kw["Directory"], kw["WithReadDirectory"], kw["WithWriteDirectory"])
+        DDAkey = (kw["Directory"], kw.get("WantReadDirectory", False), kw.get("WantWriteDirectory", False))
         try:
             return self.testedDDA[DDAkey]
         except KeyError:

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -497,13 +497,13 @@ class FCPNode:
             opts['Filename'] = file
             # need to do a TestDDARequest to have a chance of a
             # successful get to file.
-            self.testDDA(Directory=os.path.dirname(file), 
+            self.testDDA(Directory=os.path.dirname(file),
                          WantWriteDirectory=True)
     
         elif kw.get('nodata', False):
             nodata = True
             opts['ReturnType'] = "none"
-        elif kw.has_key('stream'):
+        elif 'stream' in kw:
             opts['ReturnType'] = "direct"
             opts['stream'] = kw['stream']
         else:
@@ -1369,36 +1369,36 @@ class FCPNode:
         except KeyError:
             pass # we actually have to test this dir.
         requestResult = self._submitCmd("__global", "TestDDARequest", **kw)
-        writeFilename = None;
-        kw = {};
-        kw[ 'Directory' ] = requestResult[ 'Directory' ];
-        if( requestResult.has_key( 'ReadFilename' )):
-            readFilename = requestResult[ 'ReadFilename' ];
-            readFile = open( readFilename, 'rb' );
-            readFileContents = readFile.read();
-            readFile.close();
-            kw[ 'ReadFilename' ] = readFilename;
-            kw[ 'ReadContent' ] = readFileContents;
+        writeFilename = None
+        kw = {}
+        kw['Directory'] = requestResult['Directory']
+        if requestResult.has_key('ReadFilename'):
+            readFilename = requestResult['ReadFilename']
+            readFile = open(readFilename, 'rb')
+            readFileContents = readFile.read()
+            readFile.close()
+            kw['ReadFilename'] = readFilename
+            kw['ReadContent'] = readFileContents
             
-        if( requestResult.has_key( 'WriteFilename' ) and requestResult.has_key( 'ContentToWrite' )):
-            writeFilename = requestResult[ 'WriteFilename' ];
-            contentToWrite = requestResult[ 'ContentToWrite' ];
-            writeFile = open( writeFilename, 'w+b' );
-            writeFileContents = writeFile.write( contentToWrite );
-            writeFile.close();
-            writeFileStatObject = os.stat( writeFilename );
-            writeFileMode = writeFileStatObject.st_mode;
-            os.chmod( writeFilename, writeFileMode | stat.S_IREAD | stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH );
+        if requestResult.has_key('WriteFilename') and requestResult.has_key('ContentToWrite'):
+            writeFilename = requestResult['WriteFilename']
+            contentToWrite = requestResult['ContentToWrite']
+            writeFile = open(writeFilename, "w+b")
+            writeFile.write(contentToWrite)
+            writeFile.close()
+            writeFileStatObject = os.stat(writeFilename)
+            writeFileMode = writeFileStatObject.st_mode
+            os.chmod(writeFilename, writeFileMode | stat.S_IREAD | stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
             
         responseResult = self._submitCmd("__global", "TestDDAResponse", **kw)
-        if( None != writeFilename ):
+        if writeFilename is not None:
             try:
-                os.remove( writeFilename );
-            except OSError, msg:
-                pass;
+                os.remove(writeFilename)
+            except OSError:
+                pass
         # cache this result, so we do not calculate it twice.
         self.testedDDA[DDAkey] = responseResult
-        return responseResult;
+        return responseResult
     
     #@-node:testDDA
     #@+node:addpeer

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -3278,7 +3278,7 @@ def guessMimetype(filename):
         m = mimetypes.guess_type(filename, False)[0]
     except:
         m = None
-    if m == "audio/mpegurl": # disallowed mime type
+    if m == "audio/mpegurl": # disallowed mime type by FF
         m = "audio/x-mpegurl"
     if m is None: # either an exception or a genuine None
         # FIXME: log(INFO, "Could not find mimetype for filename %s" % filename)

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -3295,7 +3295,7 @@ potentially unfitting characters.
     :returns: urlsafe basename of the file as string."""
     filename = unicode(os.path.basename(filename), encoding="utf-8", errors="ignore")
     filename = unicodedata.normalize('NFKD', filename).encode("ascii", "ignore")
-    filename = unicode(_re_slugify.sub('', filename).strip().lower())
+    filename = unicode(_re_slugify.sub('', filename).strip())
     filename = _re_slugify_multidashes.sub('-', filename)
     return str(filename)
 

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -439,7 +439,7 @@ class FCPNode:
             - priority - the PriorityClass for retrieval, default 2, may be between
               0 (highest) to 6 (lowest)
     
-            - dsnly - whether to only check local datastore
+            - dsonly - whether to only check local datastore
             - ignoreds - don't check local datastore
     
             - file - if given, this is a pathname to which to store the retrieved key
@@ -583,7 +583,7 @@ class FCPNode:
     
         Keywords for 'file' and 'data' modes:
             - chkonly - only generate CHK, don't insert - default false
-            - dontcompress - do not compress on insert - default false
+            - nocompress - do not compress on insert - default false
     
         Keywords for 'file', 'data' and 'redirect' modes:
             - mimetype - the mime type, default application/octet-stream

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -156,7 +156,7 @@ ONE_YEAR = 86400 * 365
 
 #@<<fcp_version>>
 #@+node:<<fcp_version>>
-fcpVersion = "0.2.5"
+fcpVersion = "0.3.4"
 
 #@-node:<<fcp_version>>
 #@nl

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -3048,7 +3048,6 @@ class JobTicket:
         If result is an exception object, then raises it
         """
         if isinstance(self.result, Exception):
-            self.node.shutdown()
             raise self.result
         else:
             return self.result

--- a/fcp/put.py
+++ b/fcp/put.py
@@ -234,9 +234,9 @@ def main():
             ddareq=dict()
             ddafile = os.path.abspath(infile)
 
-            ddareq["Directory"]= os.path.dirname(ddafile)
-            ddareq["WantReadDirectory"]="True"
-            ddareq["WantWriteDirectory"]="false"
+            ddareq["Directory"] = os.path.dirname(ddafile)
+            ddareq["WantReadDirectory"] = True
+            ddareq["WantWriteDirectory"] = False
             print "Absolute filepath used for node direct disk access :",ddareq["Directory"]
             print "File to insert :",os.path.basename( ddafile )
             TestDDARequest=n.testDDA(**ddareq)

--- a/fcp/put.py
+++ b/fcp/put.py
@@ -227,23 +227,23 @@ def main():
         usage("Failed to connect to FCP service at %s:%s" % (fcpHost, fcpPort))
 
 
-    TestDDARequest=False
+    TestDDARequest = False
 
     if makeDDARequest:
         if infile is not None:
-            ddareq=dict()
+            ddareq = {}
             ddafile = os.path.abspath(infile)
 
             ddareq["Directory"] = os.path.dirname(ddafile)
             ddareq["WantReadDirectory"] = True
             ddareq["WantWriteDirectory"] = False
             print "Absolute filepath used for node direct disk access :",ddareq["Directory"]
-            print "File to insert :",os.path.basename( ddafile )
-            TestDDARequest=n.testDDA(**ddareq)
-            print "Result of dda request :",TestDDARequest
+            print "File to insert :",os.path.basename(ddafile)
+            TestDDARequest = n.testDDA(**ddareq)
+            print "Result of dda request :", TestDDARequest
 
             if TestDDARequest:
-                opts["file"]=ddafile
+                opts["file"] = ddafile
                 uri = n.put(uri,**opts)
             else:
                 sys.stderr.write("%s: disk access failed to insert file %s fallback to direct\n" % (progname,ddafile) )

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -1486,11 +1486,9 @@ class SiteState:
                 try:
                     hasDDA = hasDDAtested[DDAdir]
                 except KeyError:
-                    # FIXME: node.testDDA stalls forever. Debug this.
-                    hasDDA = False
-                    # hasDDA = self.node.testDDA(Directory=DDAdir, 
-                    #                            WantReadDirectory=True, 
-                    #                            WantWriteDirectory=False)
+                    hasDDA = self.node.testDDA(Directory=DDAdir,
+                                               WantReadDirectory=True, 
+                                               WantWriteDirectory=False)
                     hasDDAtested[DDAdir] = hasDDA
 
             if hasDDA:

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -1492,6 +1492,12 @@ class SiteState:
                     hasDDAtested[DDAdir] = hasDDA
 
             if hasDDA:
+                if rec['name'].decode("utf-8") in self.generatedTextData:
+                    sizebytes = len(self.generatedTextData[rec['name']].encode("utf-8"))
+                else:
+                    sizebytes = os.path.getsize(rec['path'])
+                    rec['sizebytes'] = sizebytes
+                    rec['dda'] = True
                 return [
                     "Files.%d.Name=%s" % (n, rec['name'].decode("utf-8")),
                     "Files.%d.UploadFrom=disk" % n,
@@ -1562,7 +1568,8 @@ class SiteState:
         datalength = len(b"".join(datatoappend))
         # FIXME: Reports an erroneous Error when no physical index is present.
         reportedlength = sum(rec['sizebytes'] for rec in self.files
-                             if rec.get('target', 'separate') == 'manifest')
+                             if rec.get('target', 'separate') == 'manifest'
+                             and rec.get('dda', False) == False)
         if self.indexRec not in self.files:
             reportedlength += self.indexRec['sizebytes']
         if datalength != reportedlength:

--- a/fcp/upload.py
+++ b/fcp/upload.py
@@ -256,12 +256,9 @@ def main():
         if infile is not None:
             ddareq=dict()
             ddafile = os.path.abspath(infile)
-            ddareq["Directory"]= os.path.dirname(ddafile)
-            # FIXME: This does not work. The only reason why testDDA
-            # works is because there is an alternate way of specifying
-            # a content hash, and that way works.
-            ddareq["WantReadDirectory"]="True"
-            ddareq["WantWriteDirectory"]="false"
+            ddareq["Directory"] = os.path.dirname(ddafile)
+            ddareq["WantReadDirectory"] = True
+            ddareq["WantWriteDirectory"] = False
             print "Absolute filepath used for node direct disk access :",ddareq["Directory"]
             print "File to insert :",os.path.basename( ddafile )
             TestDDARequest=n.testDDA(**ddareq)

--- a/fcp/upload.py
+++ b/fcp/upload.py
@@ -246,25 +246,24 @@ def main():
             traceback.print_exc(file=sys.stderr)
         usage("Failed to connect to FCP service at %s:%s" % (fcpHost, fcpPort))
 
-    # FIXME: Throw out all the TestDDARequest stuff. It is not needed for putting a single file.
-    TestDDARequest=False
+    TestDDARequest = False
 
     #: The key of the uploaded file.
     freenet_uri = None
     
     if makeDDARequest:
         if infile is not None:
-            ddareq=dict()
+            ddareq = {}
             ddafile = os.path.abspath(infile)
             ddareq["Directory"] = os.path.dirname(ddafile)
             ddareq["WantReadDirectory"] = True
             ddareq["WantWriteDirectory"] = False
             print "Absolute filepath used for node direct disk access :",ddareq["Directory"]
-            print "File to insert :",os.path.basename( ddafile )
-            TestDDARequest=n.testDDA(**ddareq)
+            print "File to insert :",os.path.basename(ddafile)
+            TestDDARequest = n.testDDA(**ddareq)
 
             if TestDDARequest:
-                opts["file"]=ddafile
+                opts["file"] = ddafile
                 putres = n.put(uri,**opts)
             else:
                 sys.stderr.write("%s: disk access failed to insert file %s fallback to direct\n" % (progname,ddafile) )

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ class pyfreenet_install(distutils.command.install.install):
 
 
 setup(name="pyFreenet",
-      version="0.3.2",
+      version="0.3.4",
       description="Freenet Client Protocol Helper",
       author="Arne Babenhauserheide",
       author_email="arne_bab@web.de",

--- a/test.py
+++ b/test.py
@@ -66,9 +66,10 @@ def submitCmd(*args, **kwds):
 def fcpPluginMessage(*args, **kwds):
     '''
 
-    >>> fcpPluginMessage(id="pyfreenet",
-    ...     plugin_name="plugins.HelloFCP.HelloFCP") 
-    [{'header': 'FCPPluginReply', 'PluginName': 'plugins.HelloFCP.HelloFCP', 'Identifier': 'pyfreenet'}]
+    # this requires the hello plugin loaded in the node
+    # >>> fcpPluginMessage(id="pyfreenet",
+    # ...     plugin_name="plugins.HelloFCP.HelloFCP")
+    # [{'header': 'FCPPluginReply', 'PluginName': 'plugins.HelloFCP.HelloFCP', 'Identifier': 'pyfreenet'}]
     
     '''
     return node.fcpPluginMessage(*args, **kwds)


### PR DESCRIPTION
 if identifier is not given explicitly in the options, we need to add it to ensure that the replies find matching jobs.

This makes node.refstats() work again.
