### PR TITLE
Fixing bugs that prevented the -d (--disk) flag from working.

### DIFF
--- a/fcp/node.py
+++ b/fcp/node.py
@@ -1370,7 +1370,7 @@ class FCPNode:
             pass # we actually have to test this dir.
         requestResult = self._submitCmd("__global", "TestDDARequest", **kw)
         writeFilename = None;
-        kw = {};git
+        kw = {};
         kw[ 'Directory' ] = requestResult[ 'Directory' ];
         if( requestResult.has_key( 'ReadFilename' )):
             readFilename = requestResult[ 'ReadFilename' ];

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -498,7 +498,7 @@ class FCPNode:
             # need to do a TestDDARequest to have a chance of a
             # successful get to file.
             self.testDDA(Directory=os.path.dirname(file), 
-                         WantWriteDirectory=True)
+                         WithWriteDirectory=True)
     
         elif kw.get('nodata', False):
             nodata = True

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -498,7 +498,7 @@ class FCPNode:
             # need to do a TestDDARequest to have a chance of a
             # successful get to file.
             self.testDDA(Directory=os.path.dirname(file), 
-                         WithWriteDirectory=True)
+                         WantWriteDirectory=True)
     
         elif kw.get('nodata', False):
             nodata = True
@@ -1359,18 +1359,18 @@ class FCPNode:
                       - if status is 'failed' or 'pending', this will contain
                         a dict containing the response from node
             - Directory - directory to test
-            - WithReadDirectory - default False - if True, want node to read from directory for a put operation
-            - WithWriteDirectory - default False - if True, want node to write to directory for a get operation
+            - WantReadDirectory - default False - if True, want node to read from directory for a put operation
+            - WantWriteDirectory - default False - if True, want node to write to directory for a get operation
         """
         # cache the testDDA:
-        DDAkey = (kw["Directory"], kw["WithReadDirectory"], kw["WithWriteDirectory"])
+        DDAkey = (kw["Directory"], kw["WantReadDirectory"], kw["WantWriteDirectory"])
         try:
             return self.testedDDA[DDAkey]
         except KeyError:
             pass # we actually have to test this dir.
         requestResult = self._submitCmd("__global", "TestDDARequest", **kw)
         writeFilename = None;
-        kw = {};
+        kw = {};git
         kw[ 'Directory' ] = requestResult[ 'Directory' ];
         if( requestResult.has_key( 'ReadFilename' )):
             readFilename = requestResult[ 'ReadFilename' ];

--- a/fcp/put.py
+++ b/fcp/put.py
@@ -226,17 +226,14 @@ def main():
             traceback.print_exc(file=sys.stderr)
         usage("Failed to connect to FCP service at %s:%s" % (fcpHost, fcpPort))
 
-
-    TestDDARequest=False
-
     if makeDDARequest:
         if infile is not None:
             ddareq=dict()
             ddafile = os.path.abspath(infile)
 
             ddareq["Directory"]= os.path.dirname(ddafile)
-            ddareq["WithReadDirectory"]="True"
-            ddareq["WithWriteDirectory"]="false"
+            ddareq["WantReadDirectory"]="True"
+            ddareq["WantWriteDirectory"]="False"
             print "Absolute filepath used for node direct disk access :",ddareq["Directory"]
             print "File to insert :",os.path.basename( ddafile )
             TestDDARequest=n.testDDA(**ddareq)

--- a/fcp/put.py
+++ b/fcp/put.py
@@ -235,8 +235,8 @@ def main():
             ddafile = os.path.abspath(infile)
 
             ddareq["Directory"]= os.path.dirname(ddafile)
-            ddareq["WantReadDirectory"]="True"
-            ddareq["WantWriteDirectory"]="false"
+            ddareq["WithReadDirectory"]="True"
+            ddareq["WithWriteDirectory"]="false"
             print "Absolute filepath used for node direct disk access :",ddareq["Directory"]
             print "File to insert :",os.path.basename( ddafile )
             TestDDARequest=n.testDDA(**ddareq)

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -1489,8 +1489,8 @@ class SiteState:
                     # FIXME: node.testDDA stalls forever. Debug this.
                     hasDDA = False
                     # hasDDA = self.node.testDDA(Directory=DDAdir, 
-                    #                            WithReadDirectory=True, 
-                    #                            WithWriteDirectory=False)
+                    #                            WantReadDirectory=True,
+                    #                            WantWriteDirectory=False)
                     hasDDAtested[DDAdir] = hasDDA
 
             if hasDDA:

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -1489,8 +1489,8 @@ class SiteState:
                     # FIXME: node.testDDA stalls forever. Debug this.
                     hasDDA = False
                     # hasDDA = self.node.testDDA(Directory=DDAdir, 
-                    #                            WantReadDirectory=True, 
-                    #                            WantWriteDirectory=False)
+                    #                            WithReadDirectory=True, 
+                    #                            WithWriteDirectory=False)
                     hasDDAtested[DDAdir] = hasDDA
 
             if hasDDA:

--- a/fcp/upload.py
+++ b/fcp/upload.py
@@ -260,8 +260,8 @@ def main():
             # FIXME: This does not work. The only reason why testDDA
             # works is because there is an alternate way of specifying
             # a content hash, and that way works.
-            ddareq["WithReadDirectory"]="True"
-            ddareq["WithWriteDirectory"]="false"
+            ddareq["WantReadDirectory"]="True"
+            ddareq["WantWriteDirectory"]="false"
             print "Absolute filepath used for node direct disk access :",ddareq["Directory"]
             print "File to insert :",os.path.basename( ddafile )
             TestDDARequest=n.testDDA(**ddareq)

--- a/fcp/upload.py
+++ b/fcp/upload.py
@@ -260,8 +260,8 @@ def main():
             # FIXME: This does not work. The only reason why testDDA
             # works is because there is an alternate way of specifying
             # a content hash, and that way works.
-            ddareq["WantReadDirectory"]="True"
-            ddareq["WantWriteDirectory"]="false"
+            ddareq["WithReadDirectory"]="True"
+            ddareq["WithWriteDirectory"]="false"
             print "Absolute filepath used for node direct disk access :",ddareq["Directory"]
             print "File to insert :",os.path.basename( ddafile )
             TestDDARequest=n.testDDA(**ddareq)


### PR DESCRIPTION
`With(Read/Write)Directory` is not accepted by the node, and gives an error in verbose mode. It thinks that both `Want(Read/Write)Directory` are set to False and asks what to do. Changing the keys to `Want(Read/Write)Directory` fixes this. 

There is also a loose `TestDDARequest=False` after parsing argument flags. This prevented the DDARequest to be done at all. I figured it was a bug as it also prevents DDA requests from being done even if the `--data` flag is set.

There was also a consistency mistake where **T**rue and **f**alse capitalization was used interchangeably.