### PR TITLE
Fix bugs in the handling or arguments and mime types

### DIFF
--- a/fcp3/sitemgr.py
+++ b/fcp3/sitemgr.py
@@ -170,6 +170,7 @@ class SiteMgr:
                 maxconcurrent=self.maxConcurrent,
                 Verbosity=self.Verbosity,
                 chkCalcNode=self.chkCalcNode,
+                mtype=self.mtype,
                 )
             self.sites.append(site)
     
@@ -1556,6 +1557,7 @@ class SiteState:
                     "Files.%d.Name=%s" % (n, rec['name']),
                     "Files.%d.UploadFrom=disk" % n,
                     "Files.%d.Filename=%s" % (n, rec['path']),
+                    "Files.%d.Metadata.ContentType=%s" % (n, rec['mimetype']),
                 ]
             else:
                 if rec['name'] in self.generatedTextData:
@@ -1569,6 +1571,7 @@ class SiteState:
                     "Files.%d.Name=%s" % (n, rec['name']),
                     "Files.%d.UploadFrom=direct" % n,
                     "Files.%d.DataLength=%s" % (n, rec['sizebytes']),
+                    "Files.%d.Metadata.ContentType=%s" % (n, rec['mimetype']),
                 ]
 
             

--- a/freesitemgr
+++ b/freesitemgr
@@ -355,7 +355,7 @@ def main():
              "max-concurrent=", "quiet", "force", "no-update",
              "priority", "cron",
              "chk-calculation-node=", "max-manifest-size=",
-             "version", "index", "mime-type",
+             "version", "index=", "mime-type=",
              ]
             )
     except getopt.GetoptError:


### PR DESCRIPTION
When attempting to add a new feature, I encountered these problems in the freesitemgr.

The first problem is that the archive does not contain the mimetypes. The mimetimes are shown in the sitemap.html but not included in the manifest.

The second problem is that the parameters --index and --mime-type does not take the argument that they are supposed to do, the use of getopt.getopt is wrong.