### PR TITLE
Fix so that the uriIsPrivate takes a str

### DIFF
--- a/fcp3/node.py
+++ b/fcp3/node.py
@@ -3251,8 +3251,8 @@ def uriIsPrivate(uri):
     if "/" in extra:
         extra = extra.split("/")[0]
     extra += "/"
-    extrabytes = base64.decodestring(extra)
-    isprivate = ord(extrabytes[1])
+    extrabytes = base64.decodebytes(extra.encode())
+    isprivate = extrabytes[1]
     if isprivate:
         return True
     return False


### PR DESCRIPTION
Here is a fix to be able to enter the private URI when creating a site.

base64.decodestring is deprecated and replaced by decodebytes.