### PR TITLE
Force text plain option

### DIFF
--- a/fcp3/sitemgr.py
+++ b/fcp3/sitemgr.py
@@ -95,6 +95,7 @@ class SiteMgr:
         self.index = kw.get('index', 'index.html')
         self.sitemap = kw.get('index', 'sitemap.html')
         self.mtype = kw.get('mtype', 'text/html')
+        self.forceTextPlain = kw.get('forceTextPlain', False)
 
         self.name = "freesitemgr-" + "--".join(args)
         # To decide whether to upload index and activelink as part of
@@ -171,6 +172,7 @@ class SiteMgr:
                 Verbosity=self.Verbosity,
                 chkCalcNode=self.chkCalcNode,
                 mtype=self.mtype,
+                forceTextPlain=self.forceTextPlain,
                 )
             self.sites.append(site)
     
@@ -242,6 +244,7 @@ class SiteMgr:
                          index=self.index,
                          sitemap=self.sitemap,
                          mtype=self.mtype,
+                         forceTextPlain=self.forceTextPlain,
                          **kw)
         self.sites.append(site)
     
@@ -486,6 +489,7 @@ class SiteState:
         self.index = kw.get('index', 'index.html')
         self.sitemap = kw.get('sitemap', 'sitemap.html')
         self.mtype = kw.get('mtype', 'text/html')
+        self.forceTextPlain = kw.get('forceTextPlain', False)
         
         #print "Verbosity=%s" % self.Verbosity
     
@@ -678,6 +682,7 @@ class SiteState:
             writeVars(index=self.index)
             writeVars(sitemap=self.sitemap)
             writeVars(mtype=self.mtype)
+            writeVars(forceTextPlain=self.forceTextPlain)
             
             w("\n")
             # we should not save generated files.
@@ -1138,6 +1143,8 @@ class SiteState:
                 # new file - add it and flag update
                 log(DETAIL, "scan: file %s has been added" % name)
                 rec['uri'] = ''
+                if self.forceTextPlain:
+                    rec['mimetype'] = 'text/plain'
                 self.files.append(rec)
                 rec['state'] = 'changed'
                 self.filesDict[name] = rec

--- a/fcp3/sitemgr.py
+++ b/fcp3/sitemgr.py
@@ -170,6 +170,7 @@ class SiteMgr:
                 maxconcurrent=self.maxConcurrent,
                 Verbosity=self.Verbosity,
                 chkCalcNode=self.chkCalcNode,
+                mtype=self.mtype,
                 )
             self.sites.append(site)
     
@@ -1556,6 +1557,7 @@ class SiteState:
                     "Files.%d.Name=%s" % (n, rec['name']),
                     "Files.%d.UploadFrom=disk" % n,
                     "Files.%d.Filename=%s" % (n, rec['path']),
+                    "Files.%d.Metadata.ContentType=%s" % (n, rec['mimetype']),
                 ]
             else:
                 if rec['name'] in self.generatedTextData:
@@ -1569,6 +1571,7 @@ class SiteState:
                     "Files.%d.Name=%s" % (n, rec['name']),
                     "Files.%d.UploadFrom=direct" % n,
                     "Files.%d.DataLength=%s" % (n, rec['sizebytes']),
+                    "Files.%d.Metadata.ContentType=%s" % (n, rec['mimetype']),
                 ]
 
             

--- a/freesitemgr
+++ b/freesitemgr
@@ -271,6 +271,8 @@ def help():
     print("          - index file (default is index.html)")
     print("  -m, --mime-type")
     print("          - mime-type of the index file (default is \"text/html\")")
+    print("  --force-text-plain")
+    print("          - set mime-type to \"text/plain\" on all files")
     print("  -l, --logfile=filename")
     print("          - location of logfile (default %s)" % logFile)
     print("  -r, --priority")
@@ -355,7 +357,7 @@ def main():
              "max-concurrent=", "quiet", "force", "no-update",
              "priority", "cron",
              "chk-calculation-node=", "max-manifest-size=",
-             "version", "index=", "mime-type=",
+             "version", "index=", "mime-type=", "force-text-plain",
              ]
             )
     except getopt.GetoptError:
@@ -396,6 +398,9 @@ def main():
 
         if o in ("-m", "--mime-type"):
             opts['mtype'] = a
+
+        if o in ("--force-text-plain"):
+            opts['forceTextPlain'] = True
 
         if o == '--max-manifest-size':
             opts['maxManifestSizeBytes'] = int(float(a)*1024)

--- a/freesitemgr
+++ b/freesitemgr
@@ -355,7 +355,7 @@ def main():
              "max-concurrent=", "quiet", "force", "no-update",
              "priority", "cron",
              "chk-calculation-node=", "max-manifest-size=",
-             "version", "index", "mime-type",
+             "version", "index=", "mime-type=",
              ]
             )
     except getopt.GetoptError:


### PR DESCRIPTION
Add a --force-text-plain option that will make all found files have the mime-type text/plain.

This was needed to make it possible to fetch the site by git directly from fproxy so its use is probably limited to that use case.

The patch in https://github.com/freenet/pyFreenet/pull/31 is included in this since those fixes are required for this to work.