### PR TITLE
Fix obvious type error in guessMimetype

### DIFF
--- a/fcp3/node.py
+++ b/fcp3/node.py
@@ -3186,7 +3186,7 @@ def sha256dda(nodehelloid, identifier, path=None):
     return hashlib.sha256(tohash).digest()
 
 
-def guessMimetype(filename):
+def guessMimetype(filename: str | bytes) -> tuple[str, str] | str:
     """
     Returns a guess of a mimetype based on a filename's extension
     """
@@ -3197,10 +3197,16 @@ def guessMimetype(filename):
         if filename.endswith(".tar.bz2"):
             return ('application/x-tar', 'bzip2')
     try:
-        m = mimetypes.guess_type(filename, False)[0]
+        m = mimetypes.guess_type(filename
+                                 if isinstance(filename, str)
+                                 else filename.decode(),
+                                 False)[0]
     except TypeError:  # bytes compared to string string …
         try:
-            m = mimetypes.guess_type(filename.decode(), False)[0]
+            m = mimetypes.guess_type(filename.decode()
+                                     if isinstance(filename, bytes)
+                                     else filename,
+                                     False)[0]
         except Exception:
             m = None
     except Exception:

--- a/fcp3/node.py
+++ b/fcp3/node.py
@@ -3186,16 +3186,10 @@ def sha256dda(nodehelloid, identifier, path=None):
     return hashlib.sha256(tohash).digest()
 
 
-def guessMimetype(filename: str | bytes) -> tuple[str, str] | str:
+def guessMimetype(filename: str | bytes) -> str:
     """
     Returns a guess of a mimetype based on a filename's extension
     """
-    if isinstance(filename, bytes):
-        if filename.endswith(b".tar.bz2"):
-            return ('application/x-tar', 'bzip2')
-    else:
-        if filename.endswith(".tar.bz2"):
-            return ('application/x-tar', 'bzip2')
     try:
         m = mimetypes.guess_type(filename
                                  if isinstance(filename, str)

--- a/fcp3/node.py
+++ b/fcp3/node.py
@@ -3185,6 +3185,7 @@ def sha256dda(nodehelloid, identifier, path=None):
     tohash = b"-".join([nodehelloid.encode('utf-8'), identifier.encode('utf-8'), open(path, "rb").read()])
     return hashlib.sha256(tohash).digest()
 
+
 def guessMimetype(filename):
     """
     Returns a guess of a mimetype based on a filename's extension
@@ -3197,19 +3198,21 @@ def guessMimetype(filename):
             return ('application/x-tar', 'bzip2')
     try:
         m = mimetypes.guess_type(filename, False)[0]
-    except TypeError: # bytes compared to string string …
+    except TypeError:  # bytes compared to string string …
         try:
             m = mimetypes.guess_type(filename.decode(), False)[0]
-        except:
+        except Exception:
             m = None
-    except:
+    except Exception:
         m = None
-    if m == "audio/mpegurl": # disallowed mime type by FF
+    if m == "audio/mpegurl":  # disallowed mime type by FF
         m = "audio/x-mpegurl"
-    if m is None: # either an exception or a genuine None
-        # FIXME: log(INFO, "Could not find mimetype for filename %s" % filename)
+    if m is None:  # either an exception or a genuine None
+        # FIXME: log(INFO,
+        #            "Could not find mimetype for filename %s" % filename)
         m = "application/octet-stream"
     return m
+
 
 _re_slugify = re.compile('[^\w\s\.-]', re.UNICODE)
 _re_slugify_multidashes = re.compile('[-\s]+', re.UNICODE)

--- a/fcp3/sitemgr.py
+++ b/fcp3/sitemgr.py
@@ -1347,7 +1347,7 @@ class SiteState:
                 lines.extend([
                     "<tr>",
                     "<td>%s</td>" % size,
-                    "<td>%s</td>" % str(mimetype), # TODO: check: mimetype for tar.b2 is a list?
+                    "<td>%s</td>" % str(mimetype),
                     "<td><a href=\"%s\">%s</a></td>" % (name, name),
                     "</tr>",
                     ])


### PR DESCRIPTION
I consider the fact that guessMimetype returns a tuple on some inputs and a str on other an obvious mistake. Where the result of guessMimetype is used, it looks like a tuple is not expected.

Also, I have verified that mimetypes.guess_type handles this case and returns application/x-tar (and bzip2) already in python 3.3.

This pull request depends on #40.
