### PR TITLE
Fix the incorrectly formatted strings

### DIFF
--- a/fcp3/node.py
+++ b/fcp3/node.py
@@ -3211,8 +3211,11 @@ def guessMimetype(filename):
         m = "application/octet-stream"
     return m
 
-_re_slugify = re.compile('[^\w\s\.-]', re.UNICODE)
-_re_slugify_multidashes = re.compile('[-\s]+', re.UNICODE)
+
+_re_slugify = re.compile(r'[^\w\s\.-]', re.UNICODE)
+_re_slugify_multidashes = re.compile(r'[-\s]+', re.UNICODE)
+
+
 def toUrlsafe(filename):
     """Make a filename url-safe, keeping only the basename and killing all
 potentially unfitting characters.


### PR DESCRIPTION
Presumably these are regexps.

Starting with python3.12, there are warnings printed when this file is loaded.