### PR TITLE
Add async variant of node functions where it is useful

### DIFF
--- a/fcp3/anode.py
+++ b/fcp3/anode.py
@@ -162,8 +162,12 @@ class ANode:
         res = get_future()
         keyres = get_future()
         kwargs['callback'] = self.Callback2(res, keyres)
-        self.node.put(*args, **kwargs)
+
+        async def do(args, kwargs):
+            self.node.put(*args, **kwargs)
+            logging.debug('Queued put2 %s %s %s', args, kwargs, res)
+            await kwargs['callback'].get_a_result()
+
+        taskgroup.create_task(do(args, kwargs))
         await keyres
-        taskgroup.create_task(kwargs['callback'].get_a_result())
-        logging.debug('Queued put2 %s %s %s', args, kwargs, res)
         return keyres.result()

--- a/fcp3/anode.py
+++ b/fcp3/anode.py
@@ -18,7 +18,8 @@ import logging
 from functools import wraps
 from typing import Any, Self
 
-from .node import FCPNode
+from .node import FCPNode, \
+    FCPGetFailed, FCPPutFailed, FCPProtocolError, FCPException
 
 
 def get_future() -> asyncio.Future:
@@ -79,7 +80,18 @@ class ANode:
             elif status == 'pending':
                 pass
             elif status == 'failed':
-                self._set_exception(result)
+                match result['header']:
+                    case 'GetFailed':
+                        self._set_exception(FCPGetFailed(result))
+                    case 'PutFailed':
+                        self._set_exception(FCPPutFailed(result))
+                    case 'ProtocolError':
+                        self._set_exception(FCPProtocolError(result))
+                    case 'IdentifierCollision':
+                        self._set_exception(ANode.CallbackException(
+                            f'Duplicate job identifier {id}'))
+                    case _:
+                        self._set_exception(FCPException(result))
             else:
                 self._set_exception(ANode.CallbackException(
                     f'Unknown status {status}'))

--- a/fcp3/anode.py
+++ b/fcp3/anode.py
@@ -15,6 +15,7 @@ This was written 2026 and released under the GNU Lesser General Public License.
 
 import asyncio
 import logging
+from functools import wraps
 from typing import Any, Self
 
 from .node import FCPNode
@@ -87,6 +88,7 @@ class ANode:
             return self.fut.result()
 
     def _asyncify(f):
+        @wraps(f)
         async def wrap(*args, **kw):
             assert 'async' not in kw
             assert 'callback' not in kw
@@ -104,10 +106,14 @@ class ANode:
 
     @_asyncify
     def get(self, *args, **kwargs) -> Any:
+        """The asynchronous version of node.get().
+        When awaited it returns the result of the get."""
         self.node.get(*args, **kwargs)
 
     @_asyncify
     def put(self, *args, **kwargs) -> Any:
+        """The asynchronous version of node.put().
+        When awaited it returns the result of the get."""
         self.node.put(*args, **kwargs)
 
     class Callback2(Callback):
@@ -131,7 +137,7 @@ class ANode:
             return self.fut.result()
 
     async def put2(self, taskgroup: asyncio.TaskGroup, *args, **kwargs) -> str:
-        """Put operation that returns the key immediately when queued.
+        """Put operation that returns the key on await.
         It puts the rest of the operation into the given task group
         to be waited for afterwards.
         """

--- a/fcp3/anode.py
+++ b/fcp3/anode.py
@@ -1,0 +1,151 @@
+"""
+An implementation of a freenet client library for
+FCP v2, offering considerable flexibility.
+
+Clients should instantiate ANode, then await its methods to perform
+tasks with FCP.
+
+This module is prepared for use with the asyncio, async and await
+constructs in python3.
+
+It is a wrapper around the FCPNode and other functions in node.py.
+
+This was written 2026 and released under the GNU Lesser General Public License.
+"""
+
+import asyncio
+import logging
+from typing import Any, Self
+
+from .node import FCPNode
+
+
+def get_future() -> asyncio.Future:
+    return asyncio.get_running_loop().create_future()
+
+
+class ANode:
+    """
+    Represents an interface to freenet node via its FCP port,
+    and exposes primitives for operations in FCP.
+
+    All operations are async operations (awaitable coroutines) to work
+    with the python3 asyncio library.
+    """
+
+    def __init__(self, **kw) -> None:
+        self.kw = kw
+
+    async def start(self) -> None:
+        # TODO: Real async operation currently missing
+        # The real operation should not block on socket operations.
+        # Fixing this is not a high priority since this method is
+        # probably only called once anyway.
+        self.node = FCPNode(**self.kw)
+        self.node.noCloseSocket = False
+
+    async def __aenter__(self) -> Self:
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback) -> None:
+        await self.shutdown()
+
+    async def shutdown(self) -> None:
+        if hasattr(self, 'node'):
+            self.node.shutdown()
+
+    class CallbackException(Exception):
+        """
+        Unexpected message in the interaction to FCPNode.
+        """
+
+    class Callback(object):
+
+        def __init__(self, fut: asyncio.Future) -> None:
+            self.fut = fut
+            self.loop = asyncio.get_running_loop()
+
+        def _set_result(self, result: Any) -> None:
+            self.loop.call_soon_threadsafe(self.fut.set_result, result)
+
+        def _set_exception(self, exception: Any) -> None:
+            self.loop.call_soon_threadsafe(self.fut.set_exception, exception)
+
+        def __call__(self, status: str, result: Any) -> Any:
+            if status == 'successful':
+                self._set_result(result)
+            elif status == 'pending':
+                pass
+            elif status == 'failed':
+                self._set_exception(result)
+            else:
+                self._set_exception(ANode.CallbackException(
+                    f'Unknown status {status}'))
+
+        def get_result(self) -> Any:
+            return self.fut.result()
+
+    def _asyncify(f):
+        async def wrap(*args, **kw):
+            assert 'async' not in kw
+            assert 'callback' not in kw
+
+            logging.debug('Starting %s %s %s', f.__name__, args, kw)
+            kw['async'] = True
+
+            res = get_future()
+            kw['callback'] = ANode.Callback(res)
+            f(*args, **kw)
+            await res
+            logging.debug('Done %s %s %s %s', f.__name__, args, kw, res)
+            return res.result()
+        return wrap
+
+    @_asyncify
+    def get(self, *args, **kwargs) -> Any:
+        self.node.get(*args, **kwargs)
+
+    @_asyncify
+    def put(self, *args, **kwargs) -> Any:
+        self.node.put(*args, **kwargs)
+
+    class Callback2(Callback):
+        def __init__(self,
+                     res: asyncio.Future,
+                     key_fut: asyncio.Future) -> None:
+            self.key_fut = key_fut
+            super().__init__(res)
+
+        def __set_key_result(self, result: Any) -> None:
+            self.loop.call_soon_threadsafe(self.key_fut.set_result, result)
+
+        def __call__(self, status: str, result: Any) -> Any:
+            if status == 'pending':
+                self.__set_key_result(result['URI'])
+            else:
+                return ANode.Callback.__call__(self, status, result)
+
+        async def get_a_result(self) -> Any:
+            await self.fut
+            return self.fut.result()
+
+    async def put2(self, taskgroup: asyncio.TaskGroup, *args, **kwargs) -> str:
+        """Put operation that returns the key immediately when queued.
+        It puts the rest of the operation into the given task group
+        to be waited for afterwards.
+        """
+        assert 'async' not in kwargs
+        assert 'callback' not in kwargs
+
+        logging.debug('Starting put2 %s %s', args, kwargs)
+        kwargs['async'] = True
+
+        res = get_future()
+        keyres = get_future()
+        kwargs['callback'] = self.Callback2(res, keyres)
+        self.node.put(*args, **kwargs)
+        await keyres
+        taskgroup.create_task(kwargs['callback'].get_a_result())
+        logging.debug('Queued put2 %s %s %s', args, kwargs, res)
+        return keyres.result()

--- a/fcp3/anode.py
+++ b/fcp3/anode.py
@@ -1,16 +1,47 @@
-"""
-An implementation of a freenet client library for
+"""An implementation of a freenet client library for
 FCP v2, offering considerable flexibility.
-
-Clients should instantiate ANode, then await its methods to perform
-tasks with FCP.
 
 This module is prepared for use with the asyncio, async and await
 constructs in python3.
 
-It is a wrapper around the FCPNode and other functions in node.py.
+Clients should instantiate ANode, then await its methods to perform
+tasks with FCP.
 
-This was written 2026 and released under the GNU Lesser General Public License.
+It is implemented as a wrapper around the FCPNode and other functions
+in node.py.
+
+Example 1:
+
+    import fcp3.anode
+
+    anode = fcp3.anode.ANode()
+    try:
+        await anode.start()
+        await anode.get(...)
+        await anode.put(...)
+    finally:
+        await anode.shutdown()
+
+Example 2: Context manager
+    import fcp3.anode
+
+    async with fcp3.anode.ANode() as anode:
+        await anode.get(...)
+        await anode.put(...)
+
+Example 3: Start put based on created uri before previous upload completed
+    import asyncio
+    import fcp3.anode
+
+    async with fcp3.anode.ANode() as anode:
+        async with asyncio.TaskGroup() as tg:
+            uri1 = await anode.put2(tg, ....)
+            calculate contents based on uri1
+            uri2 = await anode.put2(tg, ...calculated contents...)
+            # Both put operations are uploading
+            # When both are completed the taskgroup finishes
+
+This was written 2026.
 """
 
 import asyncio
@@ -39,10 +70,12 @@ class ANode:
         self.kw = kw
 
     async def start(self) -> None:
-        # TODO: Real async operation currently missing
-        # The real operation should not block on socket operations.
-        # Fixing this is not a high priority since this method is
-        # probably only called once anyway.
+        """Connect to the Hyphanet node.
+
+        TODO: Should not block on the socket operations.
+        Fixing this is not a high priority since this method is
+        probably only called once anyway.
+        """
         self.node = FCPNode(**self.kw)
         self.node.noCloseSocket = False
 
@@ -54,6 +87,10 @@ class ANode:
         await self.shutdown()
 
     async def shutdown(self) -> None:
+        """Connect to the Hyphanet node.
+
+        TODO: Should not block on aquiring lock and perform socket operations.
+        """
         if hasattr(self, 'node'):
             self.node.shutdown()
 
@@ -119,13 +156,13 @@ class ANode:
     @_asyncify
     def get(self, *args, **kwargs) -> Any:
         """The asynchronous version of node.get().
-        When awaited it returns the result of the get."""
+        When awaited it finishes when the result of the get is available."""
         self.node.get(*args, **kwargs)
 
     @_asyncify
     def put(self, *args, **kwargs) -> Any:
         """The asynchronous version of node.put().
-        When awaited it returns the result of the get."""
+        When awaited it finishes when inserted."""
         self.node.put(*args, **kwargs)
 
     class Callback2(Callback):
@@ -151,7 +188,7 @@ class ANode:
     async def put2(self, taskgroup: asyncio.TaskGroup, *args, **kwargs) -> str:
         """Put operation that returns the key on await.
         It puts the rest of the operation into the given task group
-        to be waited for afterwards.
+        to be awaited later.
         """
         assert 'async' not in kwargs
         assert 'callback' not in kwargs

--- a/test_anode.py
+++ b/test_anode.py
@@ -8,6 +8,8 @@ import random
 import time
 import unittest
 import fcp3.anode
+from fcp3.node import \
+    FCPGetFailed, FCPPutFailed, FCPProtocolError, FCPException
 
 
 class SmokeTest(unittest.IsolatedAsyncioTestCase):
@@ -33,6 +35,43 @@ class SmokeTest(unittest.IsolatedAsyncioTestCase):
                 await node.get(self.uri1, realtime=True, priority=0)
             self.assertEqual(mimetype, 'application/octet-stream')
             self.assertTrue(isinstance(data, bytearray))
+
+
+class TestExceptions(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.anode = fcp3.anode.ANode()  # (verbosity=fcp3.node.DEBUG)
+
+    async def asyncSetUp(self) -> None:
+        await self.anode.start()
+
+    async def asyncTearDown(self) -> None:
+        await self.anode.shutdown()
+
+    async def testGetFailed(self) -> None:
+        with self.assertRaises(FCPGetFailed):
+            await self.anode.get(
+                "CHK@349wpfKgLk4RPZeHtvfb3mLowuEgwxnndnrKtkOfZ4M,"
+                "G1hLoVwaRCVVqRskXb9Bqg8R2aZ2zaEpQP-XXzd4jC4,AAMC--8",
+                maxretries=1)
+
+    @unittest.skip("Unclear how to create this error condition")
+    async def testPutFailed(self) -> None:
+        with self.assertRaises(FCPPutFailed):
+            await self.anode.dontknow()
+
+    async def testProtocolError(self) -> None:
+        with self.assertRaises(FCPProtocolError):
+            await self.anode.get("CHK@somethingthatisnotacorrectkey")
+
+    @unittest.skip("Unclear how to create this error condition")
+    async def testCallbackException(self) -> None:
+        with self.assertRaises(fcp3.anode.CallbackException):
+            await self.anode.dontknow("nonsense")
+
+    @unittest.skip("Unclear how to create this error condition")
+    async def testFCPException(self) -> None:
+        with self.assertRaises(FCPException):
+            await self.anode.dontknow("nonsense")
 
 
 class TestParallel(unittest.IsolatedAsyncioTestCase):

--- a/test_anode.py
+++ b/test_anode.py
@@ -1,0 +1,156 @@
+"""
+Testing fcp3.anode against a real node.
+"""
+
+import asyncio
+import logging
+import random
+import time
+import unittest
+import fcp3.anode
+
+
+class SmokeTest(unittest.IsolatedAsyncioTestCase):
+    uri1 = (
+        "USK@E0jWjfYUfJqESuiM~5ZklhTZXKCWapxl~CRj1jmZ-~I," +
+        "gl48QSprqZC1mASLbE9EOhQoBa~PheO8r-q9Lqj~uXA,AQACAAE/index.yml/2497"
+    )
+
+    async def test_simple_get(self) -> None:
+        node = fcp3.anode.ANode()
+        try:
+            await node.start()
+            mimetype, data, details = \
+                await node.get(self.uri1, realtime=True, priority=0)
+        finally:
+            await node.shutdown()
+        self.assertEqual(mimetype, 'application/octet-stream')
+        self.assertTrue(isinstance(data, bytearray))
+
+    async def test_with_node(self) -> None:
+        async with fcp3.anode.ANode() as node:
+            mimetype, data, details = \
+                await node.get(self.uri1, realtime=True, priority=0)
+            self.assertEqual(mimetype, 'application/octet-stream')
+            self.assertTrue(isinstance(data, bytearray))
+
+
+class TestParallel(unittest.IsolatedAsyncioTestCase):
+    uri_root = (
+        "USK@E0jWjfYUfJqESuiM~5ZklhTZXKCWapxl~CRj1jmZ-~I," +
+        "gl48QSprqZC1mASLbE9EOhQoBa~PheO8r-q9Lqj~uXA,AQACAAE/index.yml/"
+    )
+    DATA = b'some data'
+    DATA_KEY = 'CHK@Lw5APCokPPd8SQWxX1V87NwFSIcEGeqYvKnbwgpjIj8'
+
+    def setUp(self) -> None:
+        self.anode = fcp3.anode.ANode()  # (verbosity=fcp3.node.DEBUG)
+
+    async def asyncSetUp(self) -> None:
+        await self.anode.start()
+
+    async def asyncTearDown(self) -> None:
+        await self.anode.shutdown()
+
+    def tearDown(self) -> None:
+        self.anode = None
+
+    async def test_one_get(self) -> None:
+        mimetype, data, details = \
+            await self.anode.get(self.uri_root + "24000",
+                                 realtime=True,
+                                 priority=0)
+        self.assertEqual(mimetype, 'application/octet-stream')
+        self.assertTrue(isinstance(data, bytearray))
+
+    async def test_many_gets(self) -> None:
+        array = await asyncio.gather(
+            *[self.anode.get(self.uri_root + str(i),
+                             priority=i % 7)
+              for i in range(30)])
+        self.assertEqual(len(array), 30)
+
+    async def test_one_put(self) -> None:
+        res = await self.anode.put(data=self.DATA)
+        self.assertEqual(res[0:10], self.DATA_KEY[0:10])
+
+    async def test_one_put2(self) -> None:
+        async with asyncio.TaskGroup() as tg:
+            res = await self.anode.put2(tg, data=self.DATA)
+            self.assertEqual(res[0:10], self.DATA_KEY[0:10])
+
+    async def test_many_put(self) -> None:
+        SIZE = 5
+        array = await asyncio.gather(
+            *[self.anode.put(data=self.DATA + bytes(str(i), 'utf-8'),
+                             priority=i % 7)
+              for i in range(SIZE)])
+        self.assertEqual(len(array), SIZE)
+        for key in array:
+            self.assertTrue(isinstance(key, str))
+            self.assertEqual(key[0:4], 'CHK@')
+
+    async def create_node_with_leafs(self, size: int) -> str:
+        if size == 0:
+            return 'leaf ' + str(random.randint(0, 10000))
+        await asyncio.sleep(1)
+        return await self.anode.put(
+            data=bytes("size " + str(size) + "\n" +
+                       "\n".join(await asyncio.gather(
+                           *[self.create_node_with_leafs(
+                               random.randint(0, size - 1))
+                             for i in range(size)])), 'utf-8'))
+
+    async def check_tree(self, uri: str) -> None:
+        mimetype, data, details = \
+            await self.anode.get(uri)
+        async with asyncio.TaskGroup() as tg:
+            for line in str(data, 'utf-8').split('\n'):
+                if line.startswith('size '):
+                    continue
+                if line.startswith('leaf '):
+                    continue
+                tg.create_task(self.check_tree(line))
+
+    async def run_massive_test_for_build_and_check_trees(self) -> None:
+        for s in range(1, 30):
+            start_time = time.time()
+            key = await self.create_node_with_leafs(s)
+            print(key)
+            await self.check_tree(key)
+            elapsed_time = time.time() - start_time
+            print(f'Tree with max-depth {s} took {elapsed_time:.1f}s',
+                  'to create and retrieve')
+
+    async def create_node_with_leafs2(self,
+                                      size: int,
+                                      taskgroup: asyncio.TaskGroup) -> str:
+        if size == 0:
+            return 'leaf ' + str(random.randint(0, 10000))
+        await asyncio.sleep(1)
+        return await self.anode.put2(
+            taskgroup,
+            data=bytes("size " + str(size) + "\n" +
+                       "\n".join(await asyncio.gather(
+                           *[self.create_node_with_leafs2(
+                               random.randint(0, size - 1), taskgroup)
+                             for i in range(size)])), 'utf-8'))
+
+    async def run_massive_test_for_build_and_check_trees2(self) -> None:
+        for s in range(1, 30):
+            start_time = time.time()
+            async with asyncio.TaskGroup() as tg:
+                key = await self.create_node_with_leafs2(s, tg)
+                print(key)
+                until_waiting = time.time() - start_time
+                print(f'Waiting took {until_waiting:.1f}s to queue')
+            await self.check_tree(key)
+            elapsed_time = time.time() - start_time
+            print(f'Tree with max-depth {s} took {elapsed_time:.1f}s',
+                  'to create and retrieve')
+
+
+if __name__ == '__main__':
+    log = logging.getLogger('root')
+    # log.setLevel(logging.DEBUG)
+    unittest.main()

--- a/test_anode.py
+++ b/test_anode.py
@@ -97,17 +97,23 @@ class MassiveTimes(contextlib.AbstractContextManager):
 
 
 class LimitedTaskGroup(asyncio.TaskGroup):
-    def __init__(self, s):
+    """A taskgroup that runs a limited amount of tasks at the time.
+
+    Whenever one of the running coroutines in the taskgroup are done,
+    new ones are started.
+    """
+
+    def __init__(self, s) -> None:
         asyncio.TaskGroup.__init__(self)
         self.sem = asyncio.Semaphore(s)
 
-    async def with_coro(self, coro):
+    async def with_coro(self, coro) -> None:
         async with self.sem:
             await coro
 
-    def create_task(self, coro, *, name=None, context=None):
-        asyncio.TaskGroup.create_task(self, self.with_coro(coro),
-                                      name=name, context=context)
+    def create_task(self, coro, *, name=None, context=None) -> None:
+        return asyncio.TaskGroup.create_task(self, self.with_coro(coro),
+                                             name=name, context=context)
 
 
 class TestParallel(unittest.IsolatedAsyncioTestCase):

--- a/test_anode.py
+++ b/test_anode.py
@@ -3,11 +3,14 @@ Testing fcp3.anode against a real node.
 """
 
 import asyncio
+import contextlib
 import logging
 import random
 import time
 import unittest
 import fcp3.anode
+from typing import Tuple
+
 from fcp3.node import \
     FCPGetFailed, FCPPutFailed, FCPProtocolError, FCPException
 
@@ -74,6 +77,39 @@ class TestExceptions(unittest.IsolatedAsyncioTestCase):
             await self.anode.dontknow("nonsense")
 
 
+class MassiveTimes(contextlib.AbstractContextManager):
+    def __init__(self, depth: int) -> None:
+        self.start_time = time.time()
+        self.depth = depth
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        elapsed_time = time.time() - self.start_time
+        print(f'Tree with max-depth {self.depth} took {elapsed_time:.1f}s',
+              'to create and retrieve.')
+        contextlib.AbstractContextManager.__exit__(self,
+                                                   exc_type, exc_value,
+                                                   traceback)
+
+    def at(self, what: str) -> None:
+        until_waiting = time.time() - self.start_time
+        print(f'Tree with max-depth {self.depth} took {until_waiting:.1f}s',
+              f'until {what}.')
+
+
+class LimitedTaskGroup(asyncio.TaskGroup):
+    def __init__(self, s):
+        asyncio.TaskGroup.__init__(self)
+        self.sem = asyncio.Semaphore(s)
+
+    async def with_coro(self, coro):
+        async with self.sem:
+            await coro
+
+    def create_task(self, coro, *, name=None, context=None):
+        asyncio.TaskGroup.create_task(self, self.with_coro(coro),
+                                      name=name, context=context)
+
+
 class TestParallel(unittest.IsolatedAsyncioTestCase):
     uri_root = (
         "USK@E0jWjfYUfJqESuiM~5ZklhTZXKCWapxl~CRj1jmZ-~I," +
@@ -129,16 +165,22 @@ class TestParallel(unittest.IsolatedAsyncioTestCase):
             self.assertTrue(isinstance(key, str))
             self.assertEqual(key[0:4], 'CHK@')
 
-    async def create_node_with_leafs(self, size: int) -> str:
+    async def create_node_with_leafs(self, size: int) -> Tuple[str, int]:
         if size == 0:
-            return 'leaf ' + str(random.randint(0, 10000))
+            return ('leaf ' + str(random.randint(0, 10000)), 0)
         await asyncio.sleep(1)
-        return await self.anode.put(
+        keys = []
+        sum = 0
+        for key, count in await asyncio.gather(
+                *[self.create_node_with_leafs(
+                    random.randint(max(0, size - 3), size - 1))
+                  for i in range(size)]):
+            keys.append(key)
+            sum += count
+        return (await self.anode.put(
             data=bytes("size " + str(size) + "\n" +
-                       "\n".join(await asyncio.gather(
-                           *[self.create_node_with_leafs(
-                               random.randint(0, size - 1))
-                             for i in range(size)])), 'utf-8'))
+                       "\n".join(keys), 'utf-8')),
+                sum + 1)
 
     async def check_tree(self, uri: str) -> None:
         mimetype, data, details = \
@@ -153,51 +195,58 @@ class TestParallel(unittest.IsolatedAsyncioTestCase):
 
     async def run_massive_test_for_build_and_check_trees(self) -> None:
         for s in range(1, 30):
-            start_time = time.time()
-            key = await self.create_node_with_leafs(s)
-            print(key)
-            await self.check_tree(key)
-            elapsed_time = time.time() - start_time
-            print(f'Tree with max-depth {s} took {elapsed_time:.1f}s',
-                  'to create and retrieve')
+            with MassiveTimes(s):
+                key, count = await self.create_node_with_leafs(s)
+                print(key, count)
+                await self.check_tree(key)
 
     async def create_node_with_leafs2(self,
                                       size: int,
                                       taskgroup: asyncio.TaskGroup) -> str:
         if size == 0:
-            return 'leaf ' + str(random.randint(0, 10000))
+            return ('leaf ' + str(random.randint(0, 10000)), 0)
         await asyncio.sleep(1)
-        return await self.anode.put2(
+        keys = []
+        sum = 0
+        for key, count in await asyncio.gather(
+                *[self.create_node_with_leafs2(
+                    random.randint(max(0, size - 3), size - 1), taskgroup)
+                  for i in range(size)]):
+            keys.append(key)
+            sum += count
+        return (await self.anode.put2(
             taskgroup,
             data=bytes("size " + str(size) + "\n" +
-                       "\n".join(await asyncio.gather(
-                           *[self.create_node_with_leafs2(
-                               random.randint(0, size - 1), taskgroup)
-                             for i in range(size)])), 'utf-8'))
+                       "\n".join(keys), 'utf-8')),
+                sum + 1)
 
     async def run_massive_test_for_build_and_check_trees2(self) -> None:
-        for s in range(1, 30):
         """This is not a test of the implementation but a proof of concept.
         It creates a trees of increasing depth and should show that the
         total insert is quicker by letting the put2 return after the key
         then run the inserts in parallel (while the tree is still
         retrieveable).
         Compare with run_massive_test_for_build_and_check_trees."""
-        for s in range(9, 30):
-            start_time = time.time()
-            async with asyncio.TaskGroup() as tg:
-                key = await self.create_node_with_leafs2(s, tg)
-                print(key)
-                until_waiting = time.time() - start_time
-                print(f'Queued after {until_waiting:.1f}s ' +
-                      f'for tree with max-depth {s}.')
-            until_all_inserted = time.time() - start_time
-            print(f'All inserted after {until_all_inserted:.1f}s ' +
-                  f'for tree with max-depth {s}.')
-            await self.check_tree(key)
-            elapsed_time = time.time() - start_time
-            print(f'Create and retrieve took {elapsed_time:.1f}s',
-                  f'for tree with max-depth {s}.')
+        for s in range(1, 30):
+            with MassiveTimes(s) as timer:
+                async with asyncio.TaskGroup() as tg:
+                    key, count = await self.create_node_with_leafs2(s, tg)
+                    print(key, count)
+                    timer.at('queued')
+                timer.at('inserted')
+                await self.check_tree(key)
+
+    async def run_massive_test_for_build_and_check_trees3(self) -> None:
+        """Same as run_massive_test_for_build_and_check_trees2 but only
+        20 outstanding requests at the time."""
+        for s in range(1, 30):
+            with MassiveTimes(s) as timer:
+                async with LimitedTaskGroup(20) as tg:
+                    key, count = await self.create_node_with_leafs2(s, tg)
+                    print(key, count)
+                    timer.at('queued')
+                timer.at('inserted')
+                await self.check_tree(key)
 
 
 if __name__ == '__main__':

--- a/test_anode.py
+++ b/test_anode.py
@@ -138,16 +138,27 @@ class TestParallel(unittest.IsolatedAsyncioTestCase):
 
     async def run_massive_test_for_build_and_check_trees2(self) -> None:
         for s in range(1, 30):
+        """This is not a test of the implementation but a proof of concept.
+        It creates a trees of increasing depth and should show that the
+        total insert is quicker by letting the put2 return after the key
+        then run the inserts in parallel (while the tree is still
+        retrieveable).
+        Compare with run_massive_test_for_build_and_check_trees."""
+        for s in range(9, 30):
             start_time = time.time()
             async with asyncio.TaskGroup() as tg:
                 key = await self.create_node_with_leafs2(s, tg)
                 print(key)
                 until_waiting = time.time() - start_time
-                print(f'Waiting took {until_waiting:.1f}s to queue')
+                print(f'Queued after {until_waiting:.1f}s ' +
+                      f'for tree with max-depth {s}.')
+            until_all_inserted = time.time() - start_time
+            print(f'All inserted after {until_all_inserted:.1f}s ' +
+                  f'for tree with max-depth {s}.')
             await self.check_tree(key)
             elapsed_time = time.time() - start_time
-            print(f'Tree with max-depth {s} took {elapsed_time:.1f}s',
-                  'to create and retrieve')
+            print(f'Create and retrieve took {elapsed_time:.1f}s',
+                  f'for tree with max-depth {s}.')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
With the new async primitives the old waiting or callback interface is a little cumbersome. Here is an attempt to allow handling multiple FCP calls in parallel using the async await and asyncio.

Sofar this is only tested with the provided tests and in some scripts I am creating.